### PR TITLE
Plotting, protocol, and sample improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,8 @@ repos:
     -   id: black
         language_version: python3.10
         args: ["--target-version", "py310"]
+-   repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,16 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Changelog
 
-## Version 0.6.4
+## Version 0.7.0
  - Fixes bug that prevented loading of some aborted runs.
  - Fixes monitor's recording of temperatures.
  - Experiment.all_filters uses data if it exists; Experiment.filter_strings as a convenience function alternative.
+ - Protocol now has `Protocol.stage`, and Stage now has `Stage.step`, to provide convenient, 1-indexed access,
+   such that `protocol.stage[5]` of is stage 5 of `protocol`, not stage 6.
+ - `Experiment.change_protocol_from_now` allows convenient changes to a currently-running experiment.
+ - Some initial implementation changes to allow repeated steps (not stages).
+ - `Normalization` changed to general `Processor`.  Plotting functions can take sequences of processors to
+   process data, which now supports both normalization and smoothing.
 
 ## Version 0.6.3
  - Fixes drawer check bug.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,24 @@ SPDX-License-Identifier: AGPL-3.0-only
 # Changelog
 
 ## Version 0.7.0
+
+ - `Protocol` now has `Protocol.stage`, and Stage now has `Stage.step`, to provide convenient, 1-indexed access,
+   such that `protocol.stage[5]` of is stage 5 of `protocol`, not stage 6.
+ - `Protocol` now supports setting PRERUN and POSTRUN stages, as a series of SCPI commands.  This allows
+   the setting of things like idling temperatures and exposure times.  It is not easily usable yet, however.
+ - `Experiment.change_protocol_from_now` allows convenient changes to a currently-running experiment.
+ - `Normalization` has been renamed to `Processor`.  Plotting functions can take sequences of processors to
+   process data.  These now include:
+     - Normalization as before: `NormByMeanPerWell`, `NormByMaxPerWell`
+     - `SubtractMeanPerWell`: subtracts the mean of a particular region, applied to each well.
+     - `SmoothEMWMean`: smooths data using Pandas' ExponentialMovingWindow.mean.
+     - `SmoothWindowMean`: smooths data using Pandas' Rolling.mean or Window.mean.
+ - Some initial implementation changes to allow repeated steps (not stages).
  - Fixes bug that prevented loading of some aborted runs.
  - Fixes monitor's recording of temperatures.
  - Experiment.all_filters uses data if it exists; Experiment.filter_strings as a convenience function alternative.
- - Protocol now has `Protocol.stage`, and Stage now has `Stage.step`, to provide convenient, 1-indexed access,
-   such that `protocol.stage[5]` of is stage 5 of `protocol`, not stage 6.
- - `Experiment.change_protocol_from_now` allows convenient changes to a currently-running experiment.
- - Some initial implementation changes to allow repeated steps (not stages).
- - `Normalization` changed to general `Processor`.  Plotting functions can take sequences of processors to
-   process data, which now supports both normalization and smoothing.
+ - SCPICommand parsing improvements.
+ - Protocol printing improvements.
 
 ## Version 0.6.3
  - Fixes drawer check bug.

--- a/src/qslib/__init__.py
+++ b/src/qslib/__init__.py
@@ -5,7 +5,7 @@
 from . import protocol
 from .experiment import Experiment, PlateSetup
 from .machine import Machine, MachineStatus, RunStatus
-from .normalization import NormRaw, NormToMaxPerWell, NormToMeanPerWell
+from .processors import NormRaw, NormToMaxPerWell, NormToMeanPerWell, SmoothEMWMean
 from .protocol import CustomStep, Protocol, Stage, Step
 from .scpi_commands import AccessLevel
 from .version import __version__
@@ -24,5 +24,6 @@ __all__ = (
     "NormToMeanPerWell",
     "NormToMaxPerWell",
     "NormRaw",
+    "SmoothEMWMean",
     "CustomStep",
 )

--- a/src/qslib/experiment.py
+++ b/src/qslib/experiment.py
@@ -48,7 +48,7 @@ from ._util import _nowuuid, _pp_seqsliceint, _set_or_create
 from .base import RunStatus
 from .data import FilterDataReading, FilterSet, df_from_readings
 from .machine import Machine
-from .processors import Processor, NormRaw
+from .processors import NormRaw, Processor
 from .protocol import Protocol, Stage, Step
 from .rawquant_compat import _fdc_to_rawdata
 from .version import __version__
@@ -888,7 +888,8 @@ table, th, td {{
 
     @sample_wells.setter
     def sample_wells(self, new_sample_wells: dict[str, list[str]]) -> None:
-        self.plate_setup.sample_wells = new_sample_wells
+        raise NotImplementedError
+        # self.plate_setup.sample_wells = new_sample_wells
 
     def __init__(
         self,
@@ -1953,7 +1954,14 @@ table, th, td {{
                 for well in wells:
                     color = next(ax[0]._get_lines.prop_cycler)["color"]
 
-                    label = _gen_label(sample, well, filter, samples, wells, filters)
+                    label = _gen_label(
+                        self.plate_setup.get_descriptive_string(sample),
+                        well,
+                        filter,
+                        samples,
+                        wells,
+                        filters,
+                    )
 
                     lines.append(
                         ax[0].plot(
@@ -2189,7 +2197,7 @@ def _gen_label(
 ) -> str:
     label = ""
     if len(samples) > 1:
-        label = str(sample)
+        label = sample
     if len(wells) > 1:
         if len(label) > 0:
             label += f" ({well})"

--- a/src/qslib/experiment.py
+++ b/src/qslib/experiment.py
@@ -469,6 +469,9 @@ table, th, td {{
     ) -> Machine:
         if isinstance(machine, Machine):
             self.machine = machine
+            self.machine.max_access_level = max(
+                self.machine.max_access_level, needed_level
+            )
             return machine
         elif isinstance(machine, str):
             self.machine = Machine(
@@ -478,6 +481,7 @@ table, th, td {{
             )
             return self.machine
         elif hasattr(self, "machine") and (c := self.machine):
+            c.max_access_level = max(c.max_access_level, needed_level)
             return c
         else:
             raise ValueError(

--- a/src/qslib/experiment.py
+++ b/src/qslib/experiment.py
@@ -1743,7 +1743,7 @@ table, th, td {{
 
         ax.set_xlabel("temperature (°C)")
 
-        ax.set_ylabel(normalization.ylabel)
+        ax.set_ylabel(normalization.ylabel())
 
         if legend is True:
             if len(anneallines) < 6:
@@ -1976,10 +1976,10 @@ table, th, td {{
 
         ax[-1].set_xlabel("time (hours)")
 
-        ylabel = "fluorescence"
+        ylabel: str | None = None
         for processor in process:
-            ylabel = processor.ylabel  # FIXME
-        ax[0].set_ylabel(ylabel)
+            ylabel = processor.ylabel(ylabel)
+        ax[0].set_ylabel(ylabel or "fluorescence")
 
         if legend is True:
             if len(lines) < 6:

--- a/src/qslib/machine.py
+++ b/src/qslib/machine.py
@@ -36,10 +36,10 @@ if TYPE_CHECKING:  # pragma: no cover
     from .experiment import Experiment
 
 
-def _ensure_connection(level: AccessLevel = AccessLevel.Observer):
+def _ensure_connection(level: AccessLevel = AccessLevel.Observer) -> Any:
     def wrap(func):
         @wraps(func)
-        def wrapped(m: Machine, *args, **kwargs):
+        def wrapped(m: Machine, *args: Any, **kwargs: Any) -> Any:
             if m.automatic:
                 with m.ensured_connection(level):
                     return func(m, *args, **kwargs)
@@ -125,7 +125,7 @@ class Machine:
         return self._max_access_level
 
     @max_access_level.setter
-    def max_access_level(self, v: AccessLevel | str):
+    def max_access_level(self, v: AccessLevel | str) -> None:
         if not isinstance(v, AccessLevel):
             self._max_access_level = AccessLevel(v)
         else:
@@ -174,7 +174,11 @@ class Machine:
             return self.connection.connected
 
     def __enter__(self) -> Machine:
-        self.connect()
+        try:
+            self.connect()
+        except Exception as e:
+            self.disconnect()
+            raise e
         return self
 
     @_ensure_connection(AccessLevel.Guest)
@@ -638,7 +642,7 @@ class Machine:
                 raise ValueError(f"Unexpected power status: {s}")
 
     @power.setter
-    def power(self, value: Literal["on", "off", True, False]):
+    def power(self, value: Literal["on", "off", True, False]) -> None:
         with self.ensured_connection(AccessLevel.Controller):
             if value is True:
                 value = "on"

--- a/src/qslib/plate_setup.py
+++ b/src/qslib/plate_setup.py
@@ -105,7 +105,7 @@ class Sample:
         values = [
             x.text for x in se.findall("CustomProperty/Value") if x.text is not None
         ]
-        properties = {key: value for key, value in zip(keys, values, strict=True)}
+        properties = {key: value for key, value in zip(keys, values)}
 
         return cls(
             name=name,

--- a/src/qslib/processors.py
+++ b/src/qslib/processors.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import re
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from datetime import timedelta
@@ -17,7 +18,9 @@ ScopeType = Literal["all", "limited"]
 
 class Processor(metaclass=ABCMeta):
     @abstractmethod
-    def process_scoped(self, data: pd.DataFrame, scope: ScopeType) -> pd.DataFrame:
+    def process_scoped(
+        self, data: pd.DataFrame, scope: ScopeType
+    ) -> pd.DataFrame:  # pragma: no cover
         """
         Filter the data, and return it (possibly not a copy), *if scope is the
         minimum necessary scope for this normalization type*.  Otherwise, just
@@ -29,32 +32,34 @@ class Processor(metaclass=ABCMeta):
         ...
 
     @abstractmethod
-    def process(self, data: pd.DataFrame) -> pd.DataFrame:
+    def process(self, data: pd.DataFrame) -> pd.DataFrame:  # pragma: no cover
         ...
 
-    @property
     @abstractmethod
-    def ylabel(self) -> str:  # pragma: no cover
+    def ylabel(self, previous_label: str | None = None) -> str:  # pragma: no cover
         ...
 
 
 class NormRaw(Processor):
     """
-    A Normalizer that takes no arguments, and simply passes through raw
+    A Processor that takes no arguments, and simply passes through raw
     fluorescence values.
     """
 
     def process_scoped(self, data: pd.DataFrame, scope: ScopeType) -> pd.DataFrame:
         return data
 
-    def process(self, data: pd.DataFrame) -> pd.DataFrame:
+    def process(self, data: pd.DataFrame) -> pd.DataFrame:  # pragma: no cover
         return data
 
-    ylabel = "fluorescence"
+    def ylabel(self, previous_label: str | None = None) -> str:
+        if previous_label is None:
+            return "fluorescence (AU)"
+        return re.sub(r"\(([^)]+)\)", r"(\1, AU)", previous_label)
 
 
 @attrs.define()
-class SmoothRollingMean(Processor):
+class SmoothWindowMean(Processor):
     """
     A Processor that smooths fluorescence readings using Pandas' Rolling,
     and mean.
@@ -66,7 +71,6 @@ class SmoothRollingMean(Processor):
     win_type: str | None = None
     closed: str | None = None
     scope: ClassVar[ScopeType] = "limited"
-    ylabel = "smoothed fluorescence"
 
     def __attrs_post_init__(self):
         pass
@@ -86,6 +90,13 @@ class SmoothRollingMean(Processor):
             closed=self.closed,
         ).mean()
 
+    def ylabel(self, previous_label: str | None = None) -> str:
+        if previous_label is None:
+            return f"fluorescence (window mean {self.window})"
+        return re.sub(
+            r"\(([^)]+)\)", rf"(\1, window mean {self.window})", previous_label
+        )
+
 
 @attrs.define()
 class SmoothEMWMean(Processor):
@@ -102,10 +113,14 @@ class SmoothEMWMean(Processor):
     adjust: bool = True
     ignore_na: bool = False
     scope: ClassVar[ScopeType] = "limited"
-    ylabel = "smoothed fluorescence"
 
     def __attrs_post_init__(self):
         pass
+
+    def ylabel(self, previous_label: str | None = None) -> str:
+        if previous_label is None:
+            return f"fluorescence (EMW-smoothed)"
+        return re.sub(r"\(([^)]+)\)", rf"(\1, EMW-smoothed)", previous_label)
 
     def process_scoped(self, data: pd.DataFrame, scope: ScopeType) -> pd.DataFrame:
         if scope == self.scope:
@@ -128,7 +143,7 @@ class SmoothEMWMean(Processor):
 @dataclass(init=False)
 class NormToMeanPerWell(Processor):
     """
-    A Normalizer that divides the fluorescence reading for each (filterset, well) pair
+    A Processor that divides the fluorescence reading for each (filterset, well) pair
     by the mean value of that pair within a particular selection of data.
 
     The easiest way to use this is to give a particular stage (all data in that
@@ -196,13 +211,93 @@ class NormToMeanPerWell(Processor):
 
         return normdata
 
-    ylabel = "norm. fluorescence"
+    def ylabel(self, previous_label: str | None = None) -> str:
+        if previous_label is None:
+            return f"fluorescence (norm. to mean)"
+        return re.sub(r"\(([^)]+)\)", rf"(\1, norm. to mean)", previous_label)
+
+
+@dataclass(init=False)
+class SubtractByMeanPerWell(Processor):
+    """
+    A Processor that subtracts the fluorescence reading for each (filterset, well) pair
+    by the mean value of that pair within a particular selection of data.
+
+    The easiest way to use this is to give a particular stage (all data in that
+    stage will be used), or a stage and set of cycles (those cycles in that stage
+    will be used).  For example:
+
+    - To subtract the mean stage 8 values, use `NormToMeanPerWell(stage=8)`.
+    - To subtract the mean of the first 5 cycles of stage 2, use
+        NormToMeanPerWell(stage=2, cycle=slice(1, 6)).
+
+    `selection` allows arbitrary Pandas indexing (without the filter_set level
+    of the MultiIndex) for unusual cases.
+    """
+
+    selection: Any
+    scope: ClassVar[ScopeType] = "limited"
+
+    def __init__(
+        self,
+        stage: int | slice | Sequence[int] | None = None,
+        step: int | slice | Sequence[int] | None = None,
+        cycle: int | slice | Sequence[int] | None = None,
+        *,
+        selection: Any | None = None,
+    ):
+        if selection is not None:
+            if stage is not None:
+                raise ValueError("Selection already set, can't specify stage.")
+            if step is not None:
+                raise ValueError("Selection already set, can't specify step.")
+            if cycle is not None:
+                raise ValueError("Selection already set, can't specify cycle.")
+            self.selection = selection
+        if stage is None:
+            stage = slice(None)
+        elif isinstance(stage, int):
+            stage = [stage]
+        if step is None:
+            step = slice(None)
+        elif isinstance(step, int):
+            step = [step]
+        if cycle is None:
+            cycle = slice(None)
+        elif isinstance(cycle, int):
+            cycle = [cycle]
+
+        self.selection = (stage, step, cycle)
+
+    def process_scoped(self, data: pd.DataFrame, scope: ScopeType) -> pd.DataFrame:
+        if scope == self.scope:
+            return self.process(data)
+        else:
+            return data
+
+    def process(self, data: pd.DataFrame) -> pd.DataFrame:
+        normdata = data.copy()
+
+        means = (
+            data.loc[(slice(None), *self.selection), (slice(None), "fl")]
+            .groupby("filter_set")
+            .mean()
+        )
+
+        normdata.loc[:, (slice(None), "fl")] -= means
+
+        return normdata
+
+    def ylabel(self, previous_label: str | None = None) -> str:
+        if previous_label is None:
+            return f"fluorescence (subtr. by mean)"
+        return re.sub(r"\(([^)]+)\)", rf"(\1, subtr. by mean)", previous_label)
 
 
 @dataclass
 class NormToMaxPerWell(Processor):
     """
-    A Normalizer that divides the fluorescence reading for each (filterset, well) pair
+    A Processor that divides the fluorescence reading for each (filterset, well) pair
     by the max value of that pair within a particular selection of data.
 
     The easiest way to use this is to give a particular stage (all data in that
@@ -270,4 +365,7 @@ class NormToMaxPerWell(Processor):
 
         return normdata
 
-    ylabel = "norm fluorescence"
+    def ylabel(self, previous_label: str | None = None) -> str:
+        if previous_label is None:
+            return f"fluorescence (norm. to max)"
+        return re.sub(r"\(([^)]+)\)", rf"(\1, norm. to max)", previous_label)

--- a/src/qslib/processors.py
+++ b/src/qslib/processors.py
@@ -28,6 +28,11 @@ class Processor(metaclass=ABCMeta):
 
         This is useful for writing scope-agnostic code, provided that you call this for
         every scope before using the data.
+
+        The values for scope are:
+
+        - "all": the entire welldata array.
+        - "limited": all time points, but limited to the filter sets and samples being plotted.
         """
         ...
 

--- a/src/qslib/processors.py
+++ b/src/qslib/processors.py
@@ -8,8 +8,8 @@ from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, ClassVar, Literal, Sequence
-import attr
 
+import attrs
 import pandas as pd
 
 ScopeType = Literal["all", "limited"]
@@ -53,7 +53,7 @@ class NormRaw(Processor):
     ylabel = "fluorescence"
 
 
-@attr.define()
+@attrs.define()
 class SmoothRollingMean(Processor):
     """
     A Processor that smooths fluorescence readings using Pandas' Rolling,
@@ -87,7 +87,7 @@ class SmoothRollingMean(Processor):
         ).mean()
 
 
-@attr.define()
+@attrs.define()
 class SmoothEMWMean(Processor):
     """
     A Processor that smooths fluorescence readings using Pandas' Exponential Moving Window

--- a/src/qslib/protocol.py
+++ b/src/qslib/protocol.py
@@ -1346,6 +1346,9 @@ class Protocol(ProtoCommand):
     ----------
     stages: Iterable[Stage]
         The stages of the protocol, likely :class:`Stage`.
+    stage: _NumOrRefIndexer[Stage]
+        A more convenient way of accessing the stages of the protocol, with
+        numbering that matches the machine.
     name: str | None
         A protocol name. If not set, a timestamp will be used, unlike AB's uuid.
     volume: float
@@ -1374,6 +1377,13 @@ class Protocol(ProtoCommand):
 
     @property
     def stage(self) -> _NumOrRefIndexer[Stage]:
+        """
+        A more convenient view of :any:`Protocol.stages`.  This allows one-indexed access,
+        such that `protocol.stage[5] == protocol.stages[6]` is stage 5 of the protocol, in
+        the interpretation of tha machine.  Indexing can use slices, and is *inclusive*, so
+        `protocol.stage[5:6]` returns stages 5 and 6.  Getting, setting, and appending
+        stages are all supported through this interface.
+        """
         return _NumOrRefIndexer(self.stages)
 
     def to_scpicommand(self, **kwargs: Any) -> SCPICommand:

--- a/tests/test_experiment_file.py
+++ b/tests/test_experiment_file.py
@@ -7,7 +7,13 @@ import numpy as np
 import pytest
 
 from qslib import Experiment
-from qslib.processors import NormToMaxPerWell, NormToMeanPerWell
+from qslib.processors import (
+    NormToMaxPerWell,
+    NormToMeanPerWell,
+    SmoothEMWMean,
+    SmoothWindowMean,
+    SubtractByMeanPerWell,
+)
 
 
 @pytest.fixture(scope="module")
@@ -40,6 +46,28 @@ def test_reload(exp: Experiment, exp_reloaded: Experiment) -> None:
     assert exp.name == exp_reloaded.name
     assert exp.protocol == exp_reloaded.protocol
     assert exp.plate_setup == exp_reloaded.plate_setup
+
+
+def test_plot_ntmpw_smoothmw(exp: Experiment) -> None:
+    axf, axt = exp.plot_over_time(
+        process=[SmoothWindowMean(4), NormToMeanPerWell(1)], annotate_stage_lines=False
+    )
+    assert axf.get_ylabel() == "fluorescence (window mean 4, norm. to mean)"
+
+
+def test_plot_emw_maxperwell(exp: Experiment) -> None:
+    axf, axt = exp.plot_over_time(
+        process=[SmoothEMWMean(alpha=0.1), NormToMaxPerWell(1)],
+        annotate_stage_lines=False,
+    )
+    assert axf.get_ylabel() == "fluorescence (EMW-smoothed, norm. to max)"
+
+
+def test_plot_subtrbymean(exp: Experiment) -> None:
+    axf, axt = exp.plot_over_time(
+        process=SubtractByMeanPerWell(1), annotate_stage_lines=False
+    )
+    assert axf.get_ylabel() == "fluorescence (subtr. by mean)"
 
 
 def test_plots(exp: Experiment) -> None:

--- a/tests/test_experiment_file.py
+++ b/tests/test_experiment_file.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from qslib import Experiment
-from qslib.normalization import NormToMaxPerWell, NormToMeanPerWell
+from qslib.processors import NormToMaxPerWell, NormToMeanPerWell
 
 
 @pytest.fixture(scope="module")
@@ -29,20 +29,20 @@ def exp_reloaded(
     return Experiment.from_file(tmp_path / "test_loaded.eds")
 
 
-def test_props(exp: Experiment, exp_reloaded: Experiment):
+def test_props(exp: Experiment, exp_reloaded: Experiment) -> None:
     assert exp.name == "2020-02-20_170706"
 
     assert exp.info() == str(exp) == exp.summary()
 
 
-def test_reload(exp: Experiment, exp_reloaded: Experiment):
+def test_reload(exp: Experiment, exp_reloaded: Experiment) -> None:
     assert (exp.welldata == exp_reloaded.welldata).all().all()
     assert exp.name == exp_reloaded.name
     assert exp.protocol == exp_reloaded.protocol
     assert exp.plate_setup == exp_reloaded.plate_setup
 
 
-def test_plots(exp: Experiment):
+def test_plots(exp: Experiment) -> None:
     axf, axt = exp.plot_over_time(
         legend=False, figure_kw={"constrained_layout": False}, annotate_stage_lines=True
     )
@@ -93,5 +93,5 @@ def test_plots(exp: Experiment):
     ax2 = exp.plot_protocol()
 
 
-def test_rawquant(exp: Experiment):
+def test_rawquant(exp: Experiment) -> None:
     exp.rawdata.loc[:, :]

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -164,7 +164,7 @@ def test_refaccess():
     exp = []
 
 
-def test_exp_saveload_proto(tmp_path: pathlib.Path):
+def test_exp_saveload_proto(tmp_path: pathlib.Path) -> None:
     temperatures = list(np.linspace(51.2, 49.4, num=6))
     prot = Protocol(
         name="testproto",

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -160,6 +160,10 @@ def test_proto() -> None:
     assert prot_explicitfilter.to_scpicommand() == prot_fromstring.to_scpicommand()
 
 
+def test_refaccess():
+    exp = []
+
+
 def test_exp_saveload_proto(tmp_path: pathlib.Path):
     temperatures = list(np.linspace(51.2, 49.4, num=6))
     prot = Protocol(

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -15,42 +15,42 @@ from qslib.scpi_commands import SCPICommand  # noqa
 PROTSTRING = """PROTOCOL -volume=30 -runmode=standard testproto <multiline.protocol>
 \tSTAGE 1 STAGE_1 <multiline.stage>
 \t\tSTEP 1 <multiline.step>
-\t\t\tRAMP -incrementcycle=2 80 80 80 80 80 80
-\t\t\tHOLD -incrementcycle=2 300
+\t\t\tRAMP -incrementcycle=2 -incrementstep=2 80 80 80 80 80 80
+\t\t\tHOLD -incrementcycle=2 -incrementstep=2 300
 \t\t</multiline.step>
 \t</multiline.stage>
 \tSTAGE -repeat=27 2 STAGE_2 <multiline.stage>
 \t\tSTEP 1 <multiline.step>
-\t\t\tRAMP -increment=-1 -incrementcycle=2 80 80 80 80 80 80
-\t\t\tHOLD -incrementcycle=2 147600
+\t\t\tRAMP -increment=-1 -incrementcycle=2 -incrementstep=2 80 80 80 80 80 80
+\t\t\tHOLD -incrementcycle=2 -incrementstep=2 147600
 \t\t</multiline.step>
 \t</multiline.stage>
 \tSTAGE -repeat=5 3 STAGE_3 <multiline.stage>
 \t\tSTEP 1 <multiline.step>
-\t\t\tRAMP -incrementcycle=2 53 53 53 53 53 53
+\t\t\tRAMP -incrementcycle=2 -incrementstep=2 53 53 53 53 53 53
 \t\t\tHACFILT m4,x1,quant m5,x3,quant # qslib:default_filters
-\t\t\tHOLDANDCOLLECT -incrementcycle=2 -tiff=False -quant=True -pcr=False 120
+\t\t\tHOLDANDCOLLECT -incrementcycle=2 -incrementstep=2 -tiff=False -quant=True -pcr=False 120
 \t\t</multiline.step>
 \t</multiline.stage>
 \tSTAGE -repeat=20 4 STAGE_4 <multiline.stage>
 \t\tSTEP 1 <multiline.step>
-\t\t\tRAMP -incrementcycle=2 51.2 50.84 50.480000000000004 50.12 49.76 49.4
+\t\t\tRAMP -incrementcycle=2 -incrementstep=2 51.2 50.84 50.480000000000004 50.12 49.76 49.4
 \t\t\tHACFILT m4,x1,quant m5,x3,quant # qslib:default_filters
-\t\t\tHOLDANDCOLLECT -incrementcycle=2 -tiff=False -quant=True -pcr=False 64800000
+\t\t\tHOLDANDCOLLECT -incrementcycle=2 -incrementstep=2 -tiff=False -quant=True -pcr=False 64800000
 \t\t</multiline.step>
 \t</multiline.stage>
 \tSTAGE -repeat=20 5 STAGE_5 <multiline.stage>
 \t\tSTEP 1 <multiline.step>
-\t\t\tRAMP -incrementcycle=2 51.2 50.84 50.480000000000004 50.12 49.76 49.4
+\t\t\tRAMP -incrementcycle=2 -incrementstep=2 51.2 50.84 50.480000000000004 50.12 49.76 49.4
 \t\t\tHACFILT m4,x1,quant m5,x3,quant
-\t\t\tHOLDANDCOLLECT -incrementcycle=2 -tiff=False -quant=True -pcr=False 86400
+\t\t\tHOLDANDCOLLECT -incrementcycle=2 -incrementstep=2 -tiff=False -quant=True -pcr=False 86400
 \t\t</multiline.step>
 \t</multiline.stage>
 \tSTAGE -repeat=100 6 STAGE_6 <multiline.stage>
 \t\tSTEP 1 <multiline.step>
-\t\t\tRAMP -incrementcycle=2 51.2 50.84 50.480000000000004 50.12 49.76 49.4
+\t\t\tRAMP -incrementcycle=2 -incrementstep=2 51.2 50.84 50.480000000000004 50.12 49.76 49.4
 \t\t\tHACFILT m4,x1,quant m5,x3,quant
-\t\t\tHOLDANDCOLLECT -incrementcycle=2 -tiff=False -quant=True -pcr=False 1200
+\t\t\tHOLDANDCOLLECT -incrementcycle=2 -incrementstep=2 -tiff=False -quant=True -pcr=False 1200
 \t\t</multiline.step>
 \t</multiline.stage>
 </multiline.protocol>


### PR DESCRIPTION
- [X] Add support to `Sample` for a description ('Comment' in AB) and custom properties, both interoperable with AB.
- [X] Refactor `PlateSetup` to better handle samples with more than a name.  Wells now included in the `Sample` object.
- [X] For `plot_over_time`, use description if available.
- [x] For `plot_anneal_melt`, use description if available.
- [X] Rename Normalization to Processor, to reflect them now doing more than just normalization, allow a sequence of processors for plotting.
- [x] Also implement for `plot_anneal_melt`
- [X] Implement processors for moving-average and exponential-moving-window average.
- [x] Implement processor for additive adjustments.
- [X] Implement support for `SCPICommandLike`-based PRERUN and POSTRUN in protocols.
- [X] Fix command parsing for commands including ":", and commands not including arguments. 
- [ ] Tests
- [ ] Documentation